### PR TITLE
2 - Update ContextLoaderListener to current name

### DIFF
--- a/tool/src/main/webapp/WEB-INF/web.xml
+++ b/tool/src/main/webapp/WEB-INF/web.xml
@@ -78,7 +78,7 @@
    </servlet>
 
    <listener>
-        <listener-class>org.sakaiproject.util.ContextLoaderListener</listener-class>
+        <listener-class>org.sakaiproject.util.SakaiContextLoaderListener</listener-class>
     </listener>
 
     <listener>


### PR DESCRIPTION
Sakai 11 switched the name of the context loader listener.
This fixes that.

This would fix Issue #2.
