### PR TITLE
CC-2: migrate master to 13-SNAPSHOT

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
       <artifactId>certification-base</artifactId>
       <groupId>com.rsmart</groupId>
-      <version>12-SNAPSHOT</version>
+      <version>13-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/deploy/pom.xml
+++ b/deploy/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>certification-base</artifactId>
         <groupId>com.rsmart</groupId>
-        <version>12-SNAPSHOT</version>
+        <version>13-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Certification Shared Library Deployer</name>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>certification-base</artifactId>
         <groupId>com.rsmart</groupId>
-        <version>12-SNAPSHOT</version>
+        <version>13-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>certification-base</artifactId>
         <groupId>com.rsmart</groupId>
-        <version>12-SNAPSHOT</version>
+        <version>13-SNAPSHOT</version>
     </parent>
 
     <artifactId>certification-model</artifactId>

--- a/pack/pom.xml
+++ b/pack/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>certification-base</artifactId>
         <groupId>com.rsmart</groupId>
-        <version>12-SNAPSHOT</version>
+        <version>13-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.sakaiproject</groupId>
         <artifactId>master</artifactId>
-        <version>12-SNAPSHOT</version>
+        <version>13-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>certification-base</artifactId>
         <groupId>com.rsmart</groupId>
-        <version>12-SNAPSHOT</version>
+        <version>13-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/CC-2

Core Sakai master has been transitioned to 13-SNAPSHOT; Certification should mimic this change.