### PR TITLE
CC-7: missing variable breaks JavaScript functionality on the report page

### DIFF
--- a/tool/src/main/webapp/WEB-INF/jsp/reportView.jsp
+++ b/tool/src/main/webapp/WEB-INF/jsp/reportView.jsp
@@ -292,6 +292,7 @@
                 var filterDateType = $.cookie("filterDateType");
                 var filterStartDate = $.cookie("filterStartDate");
                 var filterEndDate = $.cookie("filterEndDate");
+                var filterHistorical = $.cookie("filterHistorical");
 
                 /*do a click event - this way the css on the dateRange will be applied*/
                 $("input[name=show][value=" + filterType + "]").click();


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/CC-7

Clicking on the Apply button in the display options *OR* changing the number of results on the paginator causes most of the buttons on the page to not function as expected. The initial change will occur successfully, but changing it again will not work; the page simply refreshes to the display option you had selected. 

Workaround, refresh tool.

Buttons that break:
- Return to Certificates List
- Paginator navigation
- Paginator number of results dropdown
- Reset button
- Apply button (and changing display option)

Buttons that work:
- Export as CSV 
- Portal buttons (tool reset, link, help)
- table sorting