### PR TITLE
CC-8: display variables to be substituted as readable strings from resource bundles

### DIFF
--- a/tool/src/main/java/com/rsmart/certification/tool/utils/CertificateToolState.java
+++ b/tool/src/main/java/com/rsmart/certification/tool/utils/CertificateToolState.java
@@ -200,6 +200,19 @@ public class CertificateToolState
         this.templateFields = templateFields;
     }
 
+    public Map<String, String> getFieldToDescription()
+    {
+        HashMap<String, String> fieldToDesc = new HashMap<>();
+        for (String key : getTemplateFields().keySet())
+        {
+            String expression = getTemplateFields().get(key);
+            String description = getPredifinedFields().get(expression);
+            fieldToDesc.put(key, description);
+        }
+
+        return fieldToDesc;
+    }
+
     /**
      *
      * @return a map of ${} format to description

--- a/tool/src/main/webapp/WEB-INF/jsp/createCertificateFour.jsp
+++ b/tool/src/main/webapp/WEB-INF/jsp/createCertificateFour.jsp
@@ -91,7 +91,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <c:forEach items="${certificateToolState.certificateDefinition.fieldValues}" var="tField" >
+                    <c:forEach items="${certificateToolState.fieldToDescription}" var="tField" >
                         <tr>
                             <td>${tField.key}</td>
                             <td>${tField.value}</td>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/CC-8

Upon activating a certificate with PDF fields and values the 'Value to be substituted' column displays text that isn't user friendly. Screenshot in JIRA.