### PR TITLE
CC-29: fix ClassDefNotFound exception in 20.x

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -22,14 +22,10 @@
         <dependency>
             <groupId>org.sakaiproject.certification</groupId>
             <artifactId>certification-api</artifactId>
-            <scope>provided</scope>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.sakaiproject.certification</groupId>
             <artifactId>certification-model</artifactId>
-            <scope>provided</scope>
-            <version>${project.version}</version>
         </dependency>
 
         <!-- Sakai -->

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -24,7 +24,6 @@
         <dependency>
             <groupId>org.sakaiproject.certification</groupId>
             <artifactId>certification-api</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,28 @@
         <module>model</module>
     </modules>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.sakaiproject.certification</groupId>
+                <artifactId>certification-api</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.sakaiproject.certification</groupId>
+                <artifactId>certification-model</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>javax.servlet</groupId>
+                <artifactId>jstl</artifactId>
+                <version>1.1.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <profiles>
         <profile>
             <id>snapshots</id>
@@ -47,5 +69,4 @@
             </repositories>
         </profile>
     </profiles>
-
 </project>

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -19,26 +19,20 @@
         <dependency>
             <groupId>org.sakaiproject.certification</groupId>
             <artifactId>certification-api</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.sakaiproject.certification</groupId>
             <artifactId>certification-model</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <!-- Sakai -->
         <dependency>
             <groupId>org.sakaiproject.kernel</groupId>
             <artifactId>sakai-kernel-api</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.sakaiproject.kernel</groupId>
             <artifactId>sakai-component-manager</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.sakaiproject.kernel</groupId>
@@ -49,7 +43,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -58,6 +51,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
+            <scope>compile</scope>
         </dependency>
 
         <!-- Others -->
@@ -75,15 +69,16 @@
             <artifactId>javax.servlet.jsp-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>jstl</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${sakai.jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>${sakai.commons.lang3.version}</version>
-            <type>jar</type>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/CC-29

Accessing the tool in a 20.x instance will produce the following exception:

`java.lang.NoClassDefFoundError: javax/servlet/jsp/jstl/core/Config`

Fix this class loader issue so the tool works as it did pre-Sakai 20. This is fallout from SAK-41010, which moved the JSTL lib from shared lib to individual tools' lib, to facilitate upgrading JSF tools one at a time.