### PR TITLE
CC-30 - CandidateDetailProvider is not getting injected into CertificateServiceHibernateImpl

### DIFF
--- a/impl/src/webapp/WEB-INF/components.xml
+++ b/impl/src/webapp/WEB-INF/components.xml
@@ -67,7 +67,7 @@
         <!-- Certification services -->
         <property name="documentTemplateService" ref="org.sakaiproject.certification.api.DocumentTemplateService"/>
         <property name="candidateDetailProvider">
-            <bean class="org.sakaiproject.certification.impl.OptionalFactoryBean"/>
+            <bean name="org.sakaiproject.user.api.CandidateDetailProvider" class="org.sakaiproject.certification.impl.OptionalFactoryBean"/>
         </property>
 
         <!-- Member variables -->


### PR DESCRIPTION
When running a Sakai instance with CandidateDetailProviders configured, I debugged OptionalFactoryBean, and I'm finding that the current configuration attempts to inject org.sakaiproject.certification.impl.OptionalFactoryBean into itself; then CertificateServiceHibernateImpl's candidateDetailProvider is left null.