### PR TITLE
CC-34 criterion validation not working properly

### DIFF
--- a/impl/src/bundle/org/sakaiproject/certification/Messages.properties
+++ b/impl/src/bundle/org/sakaiproject/certification/Messages.properties
@@ -16,16 +16,21 @@ message.noitems.duedate=You must add a gradebook item with a due date to use thi
 message.noitems.greaterthanscore=You must add a gradebook item to use this rule
 message.noitems.willexpire=You must add a gradebook item to use this rule
 
-value.noGradebook=You must add a gradebook to this site to use this requirement
-value.emptyGradebook=Could not create this requirement - is the gradebook empty?
-value.noDueDates=Could not create this requirement - requires a gradebook item with a due date
-value.minRequired=Minimum score is a required field
-value.expiryOffsetRequired=Months until expiration is a required field
-value.notanumber={0} is not a number
-value.toohigh=value {0} is higher than the maximum score
-value.negativenumber=value {0} is less than zero
-value.wholeNumberRequired={0} is not a whole number
+value.noGradebook=You must add a Gradebook to this site to use this requirement.
+value.emptyGradebook=Could not create this requirement - is the Gradebook empty?
+value.noDueDates=Could not create this requirement - requires a Gradebook item with a due date.
+value.minRequired=Minimum score is required.
+value.expiryOffsetRequired=Months until expiration is required.
+value.notanumber=The value provided ({0}) is not a number.
+value.toohigh=The value provided ({0}) is higher than the maximum score of the selected Gradebook item ({1}).
+value.tooHighCourseGrade=The value provided ({0}) is higher than the total available points comprising the course grade ({1}).
+value.negativenumber=The value provided ({0}) is less than zero.
+value.wholeNumberRequired=The value provided ({0}) is not a whole number.
 error.cannotEvaluate=ERROR: Could not evaluate rule template
+
+expiry.requirements=Please provide a positive, whole number for the expiry.
+courseGrade.requirements=Please provide a positive number for the course grade requirement.
+gradebookItem.requirements=Please provide a positive number for the Gradebook item requirement.
 
 cert.unavailable=This requirement has not been met
 cert.available=This requirement has been met

--- a/impl/src/java/org/sakaiproject/certification/criteria/impl/gradebook/GradebookCriteriaFactory.java
+++ b/impl/src/java/org/sakaiproject/certification/criteria/impl/gradebook/GradebookCriteriaFactory.java
@@ -97,6 +97,10 @@ public class GradebookCriteriaFactory implements CriteriaFactory {
     private static final String ERROR_WHOLE_NUMBER_REQUIRED = "value.wholeNumberRequired";
     private static final String ERROR_NEGATIVE_NUMBER = "value.negativenumber";
     private static final String ERROR_TOO_HIGH = "value.toohigh";
+    private static final String ERROR_TOO_HIGH_COURSE_GRADE = "value.tooHighCourseGrade";
+    private static final String EXPIRY_REQUIREMENTS = "expiry.requirements";
+    private static final String SCORE_REQUIREMENTS = "gradebookItem.requirements";
+    private static final String COURSE_GRADE_REQUIREMENTS = "courseGrade.requirements";
 
     public void init() {
         gbItemScoreTemplate = new GreaterThanScoreCriteriaTemplate(this);
@@ -107,9 +111,6 @@ public class GradebookCriteriaFactory implements CriteriaFactory {
 
         gbDueDatePassedTemplate = new DueDatePassedCriteriaTemplate(this);
         gbDueDatePassedTemplate.setResourceLoader(resourceLoader);
-
-        gbFinalGradeScoreTemplate = new FinalGradeScoreCriteriaTemplate(this);
-        gbFinalGradeScoreTemplate.setResourceLoader(resourceLoader);
 
         gbWillExpireTemplate = new WillExpireCriteriaTemplate(this);
         gbWillExpireTemplate.setResourceLoader(resourceLoader);
@@ -481,7 +482,9 @@ public class GradebookCriteriaFactory implements CriteriaFactory {
                             InvalidBindingException ibe = new InvalidBindingException();
                             ibe.setBindingKey(KEY_SCORE);
                             ibe.setBindingValue(value);
-                            ibe.setLocalizedMessage(rl.getFormattedMessage(ERROR_NAN, new Object[] {value}));
+                            String errorMessage = rl.getFormattedMessage(ERROR_NAN, new Object[] {value}) + " " +
+                                                  (template instanceof FinalGradeScoreCriteriaTemplate ? rl.getString(COURSE_GRADE_REQUIREMENTS) : rl.getString(SCORE_REQUIREMENTS));
+                            ibe.setLocalizedMessage(errorMessage);
                             throw ibe;
                         }
                     }
@@ -489,7 +492,7 @@ public class GradebookCriteriaFactory implements CriteriaFactory {
                     InvalidBindingException ibe = new InvalidBindingException ();
                     ibe.setBindingKey(variable.getVariableKey());
                     ibe.setBindingValue(value);
-                    ibe.setLocalizedMessage(rl.getFormattedMessage(ERROR_MIN_REQUIRED, new Object[] {value}));
+                    ibe.setLocalizedMessage(rl.getString(ERROR_MIN_REQUIRED));
                     throw ibe;
 
                 } else if (variable.getVariableKey().equals(KEY_EXPIRY_OFFSET)) {
@@ -500,7 +503,7 @@ public class GradebookCriteriaFactory implements CriteriaFactory {
                             InvalidBindingException ibe = new InvalidBindingException();
                             ibe.setBindingKey(KEY_EXPIRY_OFFSET);
                             ibe.setBindingValue(value);
-                            ibe.setLocalizedMessage(rl.getFormattedMessage(ERROR_NAN, new Object[] {value}));
+                            ibe.setLocalizedMessage(rl.getFormattedMessage(ERROR_NAN, new Object[] {value}) + " " + rl.getString(EXPIRY_REQUIREMENTS));
                             throw ibe;
                         }
 
@@ -510,7 +513,7 @@ public class GradebookCriteriaFactory implements CriteriaFactory {
                             InvalidBindingException ibe = new InvalidBindingException();
                             ibe.setBindingKey(KEY_EXPIRY_OFFSET);
                             ibe.setBindingValue(value);
-                            ibe.setLocalizedMessage(rl.getFormattedMessage(ERROR_WHOLE_NUMBER_REQUIRED, new Object[] {value}));
+                            ibe.setLocalizedMessage(rl.getFormattedMessage(ERROR_WHOLE_NUMBER_REQUIRED, new Object[] {value})+ " " + rl.getString(EXPIRY_REQUIREMENTS));
                             throw ibe;
                         }
                     }
@@ -556,7 +559,7 @@ public class GradebookCriteriaFactory implements CriteriaFactory {
                 InvalidBindingException ibe = new InvalidBindingException();
                 ibe.setBindingKey(KEY_SCORE);
                 ibe.setBindingValue(scoreStr);
-                ibe.setLocalizedMessage (rl.getFormattedMessage(ERROR_NAN, new Object[] {scoreStr} ));
+                ibe.setLocalizedMessage (rl.getFormattedMessage(ERROR_NAN, new Object[] {scoreStr}) + " " + rl.getString(SCORE_REQUIREMENTS));
                 throw ibe;
             }
 
@@ -564,7 +567,7 @@ public class GradebookCriteriaFactory implements CriteriaFactory {
                 InvalidBindingException ibe = new InvalidBindingException();
                 ibe.setBindingKey(KEY_SCORE);
                 ibe.setBindingValue(scoreStr);
-                ibe.setLocalizedMessage (rl.getFormattedMessage(ERROR_NEGATIVE_NUMBER, new Object[] {scoreStr}));
+                ibe.setLocalizedMessage (rl.getFormattedMessage(ERROR_NEGATIVE_NUMBER, new Object[] {scoreStr}) + " " + rl.getString(SCORE_REQUIREMENTS));
                 throw ibe;
             }
 
@@ -576,7 +579,7 @@ public class GradebookCriteriaFactory implements CriteriaFactory {
                 if (assn.getPoints()==0) {
                     ibe.setLocalizedMessage(rl.getFormattedMessage(ERROR_EMPTY_GRADEBOOK, new Object[] {scoreStr} ));
                 } else {
-                    ibe.setLocalizedMessage (rl.getFormattedMessage(ERROR_TOO_HIGH, new Object[] {scoreStr}));
+                    ibe.setLocalizedMessage (rl.getFormattedMessage(ERROR_TOO_HIGH, new Object[] {scoreStr, assn.getPoints()}));
                 }
 
                 throw ibe;
@@ -636,17 +639,17 @@ public class GradebookCriteriaFactory implements CriteriaFactory {
             try {
                 score = Double.parseDouble(scoreStr);
             } catch (NumberFormatException nfe) {
-                ibe.setLocalizedMessage (rl.getFormattedMessage(ERROR_NAN, new Object[] {scoreStr}));
+                ibe.setLocalizedMessage (rl.getFormattedMessage(ERROR_NAN, new Object[] {scoreStr}) + " " + rl.getString(COURSE_GRADE_REQUIREMENTS));
                 throw ibe;
             }
 
             if (score < 0) {
-                ibe.setLocalizedMessage (rl.getFormattedMessage(ERROR_NEGATIVE_NUMBER, new Object[] {scoreStr}));
+                ibe.setLocalizedMessage (rl.getFormattedMessage(ERROR_NEGATIVE_NUMBER, new Object[] {scoreStr}) + " " + rl.getString(COURSE_GRADE_REQUIREMENTS));
                 throw ibe;
             }
 
             if (score > totalAvailable) {
-                ibe.setLocalizedMessage (rl.getFormattedMessage(ERROR_TOO_HIGH, new Object[] {scoreStr}));
+                ibe.setLocalizedMessage (rl.getFormattedMessage(ERROR_TOO_HIGH_COURSE_GRADE, new Object[] {scoreStr, totalAvailable}));
                 throw ibe;
             }
 
@@ -677,12 +680,12 @@ public class GradebookCriteriaFactory implements CriteriaFactory {
             try {
                 expiryOffset = Integer.parseInt(strExpiryOffset);
             } catch (NumberFormatException e) {
-                ibe.setLocalizedMessage (rl.getFormattedMessage(ERROR_NAN, new Object[] {strExpiryOffset} ));
+                ibe.setLocalizedMessage (rl.getFormattedMessage(ERROR_NAN, new Object[] {strExpiryOffset}) + " " + rl.getString(EXPIRY_REQUIREMENTS));
                 throw ibe;
             }
 
             if (expiryOffset < 0) {
-                ibe.setLocalizedMessage (rl.getFormattedMessage(ERROR_NEGATIVE_NUMBER, new Object[] {strExpiryOffset} ));
+                ibe.setLocalizedMessage (rl.getFormattedMessage(ERROR_NEGATIVE_NUMBER, new Object[] {strExpiryOffset}) + " " + rl.getString(EXPIRY_REQUIREMENTS));
                 throw ibe;
             }
 

--- a/tool/src/bundle/org/sakaiproject/certification/tool/Messages.properties
+++ b/tool/src/bundle/org/sakaiproject/certification/tool/Messages.properties
@@ -107,7 +107,7 @@ form.label.expiryOffset1=This certificate is valid for
 form.label.expiryOffset2= months from the date of issue.
 form.error.expiryOffset.notNumber=The value entered for the certificate validity period is not acceptable. Please enter a positive, whole number or leave the field blank.
 form.expiry.onlyCriterionError=You cannot have an expiry date as the only certificate requirement.
-form.expiry.tooMany=You cannot have more than one expiry date requirement.
+form.error.tooManyExpiry=You cannot have more than one expiry date requirement.
 
 instructions.admin=Offer certificates to your site participants when they meet your requirements.
 instructions.student=View the status of your certificates below. Click the "View" link to download any certificates you achieved.

--- a/tool/src/webapp/jsp/createCertificateTwo.jsp
+++ b/tool/src/webapp/jsp/createCertificateTwo.jsp
@@ -239,14 +239,14 @@
                     appendCriterionToDiv(data);
                 },
                 error: function (xhr, status, errorThrown) {
-                    var patt = new RegExp("ERROR_MESSAGE(.*?)/ERROR_MESSAGE");
+                    var patt = new RegExp("ERROR_MESSAGE(.*?)&#47;ERROR_MESSAGE");
 
                     var match = patt.exec(xhr.responseText);
 
                     if (match !== null) {
                         $("#submitError").html(match[1]).removeClass("hidden");
                     } else if(xhr.responseText.indexOf( "**TooManyExpiry**" ) !== -1) {
-                        $("#submitError").html("<spring:message code='form.expiry.tooMany' />").removeClass("hidden");
+                        $("#submitError").html("<spring:message code='form.error.tooManyExpiry' />").removeClass("hidden");
                     } else {
                         $("#submitError").html("<spring:message code='form.error.criteriaProcessingError' />").removeClass("hidden");
                     }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/CC-34

If you provide invalid input for any of the criterion types, you will be presented with the following generic error message:

> An error occurred processing award requirements.

There is validation happening on the server side, and specific error messages are generated and passed to the client. The client side JavaScript uses a regex to parse the `responseText`, but the regex pattern is malformed and thus never catches these specific validation messages. It essentially tosses out the useful information provided by the server, and instead falls through to the catch all unknown/generic error which is what you see in the UI.

Fixing the regex seems to be enough to get these value specific validation error messages flowing through to the UI. The error messages themselves have been touched up, as they're not the greatest.